### PR TITLE
Now we can remove the close event

### DIFF
--- a/packages/web3-core-requestmanager/src/index.js
+++ b/packages/web3-core-requestmanager/src/index.js
@@ -147,8 +147,6 @@ RequestManager.prototype.setProvider = function (provider, net) {
                 _this.provider.emit('end', event);
             }
         };
-        // TODO: Remove close once the standard allows it
-        this.provider.on('close', disconnect);
         this.provider.on('disconnect', disconnect);
 
         // TODO add end, timeout??


### PR DESCRIPTION
and only let disconnect.
Following https://github.com/ChainSafe/web3.js/issues/4786

## Description

Close event can now be removed. It is a deprecated event that is replaced by disconnect.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

It was just a deprecation warning.

## Checklist:

- [y] I have selected the correct base branch.
- [y] I have performed a self-review of my own code.
- [y] I have commented my code, particularly in hard-to-understand areas.
- [n] I have made corresponding changes to the documentation.
- [y] My changes generate no new warnings. And one warning less
- [?] Any dependent changes have been merged and published in downstream modules.
- [n] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [n] I ran `npm run test:unit` with success.
- [n] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [n] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [n] I have tested my code on the live network.
- [n] I have checked the Deploy Preview and it looks correct.
- [n] I have updated the `CHANGELOG.md` file in the root folder.
